### PR TITLE
More options for the dash button

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,13 @@ RUN apt-get update && apt-get install libpcap-dev -y
 WORKDIR /opt/mqtt-dasher
 RUN mkdir bin
 COPY ./bin/mqtt-dasher ./bin/mqtt-dasher
-COPY server.js .
-COPY README.md .
+
 COPY package.json .
 
 RUN npm install
+
+COPY server.js .
+COPY README.md .
+
 
 CMD ["/opt/mqtt-dasher/bin/mqtt-dasher"]

--- a/DockerfileRPI
+++ b/DockerfileRPI
@@ -19,10 +19,12 @@ RUN apt-get update && apt-get install git -y
 WORKDIR /opt/mqtt-dasher
 RUN mkdir bin
 COPY ./bin/mqtt-dasher ./bin/mqtt-dasher
+
+COPY package.json .
+RUN npm install
+
 COPY server.js .
 COPY README.md .
-COPY package.json .
 
-RUN npm install
 
 CMD ["/opt/mqtt-dasher/bin/mqtt-dasher"]

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ mqtt:
 buttons:
     44:65:0d:dc:51:50:
         name: nerf_supplies
-        iface: eth0     # optional
+        interface: eth0     # optional
         timeout: 5000   # optional (time in ms)
         protocol: arp   # optional (one of {udp, arp, all})
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ buttons:
     44:65:0d:dc:51:50:
         name: nerf_supplies
         iface: eth0     # optional
+        timeout: 5000   # optional (time in ms)
+        protocol: arp   # optional (one of {udp, arp, all})
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ mqtt:
     preface: dash
 
 buttons:
-    44:65:0d:dc:51:50: nerf_supplies
+    44:65:0d:dc:51:50:
+        name: nerf_supplies
+        iface: eth0     # optional
 
 ```
 

--- a/_config.yml
+++ b/_config.yml
@@ -10,4 +10,6 @@ mqtt:
     preface: dash
 
 buttons:
-    44:65:0d:dc:51:50: nerf_supplies
+    44:65:0d:dc:51:50:
+      name: nerf_supplies
+#      iface: eth0

--- a/_config.yml
+++ b/_config.yml
@@ -13,3 +13,5 @@ buttons:
     44:65:0d:dc:51:50:
       name: nerf_supplies
 #      iface: eth0
+      timeout: 5000
+      protocol: arp

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "async": "^2.0.0",
     "js-yaml": "^3.6.1",
     "mqtt": "^1.12.0",
-    "node-dash-button": "^0.5.0",
+    "node-dash-button": "^0.6.1",
     "request": "^2.73.0",
     "winston": "^2.2.0"
   }

--- a/server.js
+++ b/server.js
@@ -95,12 +95,15 @@ async.series([
         winston.info('Listening for %d buttons', Object.keys(config.buttons).length);
 
         Object.keys(config.buttons).forEach(function (macAddress) {
-            var topic = config.buttons[macAddress].name;
-            var iface = config.buttons[macAddress].iface;
+            var button = config.buttons[macAddress];
+            var topic = button.name;
+            var iface = button.iface || null;
+            var timeout = button.timeout || null;
+            var protocol = button.protocol || null;
             if (config.mqtt.preface) {
               topic = config.mqtt.preface + '/' + topic;
             }
-            buttons[macAddress] = DashButton(macAddress, iface);
+            buttons[macAddress] = DashButton(macAddress, iface, timeout, protocol);
             buttons[macAddress].on('detected', buttonEvent.bind(null, macAddress, topic));
         });
 

--- a/server.js
+++ b/server.js
@@ -97,13 +97,10 @@ async.series([
         Object.keys(config.buttons).forEach(function (macAddress) {
             var button = config.buttons[macAddress];
             var topic = button.name;
-            var iface = button.iface || null;
-            var timeout = button.timeout || null;
-            var protocol = button.protocol || null;
             if (config.mqtt.preface) {
               topic = config.mqtt.preface + '/' + topic;
             }
-            buttons[macAddress] = DashButton(macAddress, iface, timeout, protocol);
+            buttons[macAddress] = DashButton(macAddress, button.interface, button.timeout, button.protocol);
             buttons[macAddress].on('detected', buttonEvent.bind(null, macAddress, topic));
         });
 

--- a/server.js
+++ b/server.js
@@ -96,10 +96,11 @@ async.series([
 
         Object.keys(config.buttons).forEach(function (macAddress) {
             var topic = config.buttons[macAddress];
+            var iface = config.buttons[macAddress].iface;
             if (config.mqtt.preface) {
               topic = config.mqtt.preface + '/' + topic;
             }
-            buttons[macAddress] = DashButton(macAddress);
+            buttons[macAddress] = DashButton(macAddress, iface);
             buttons[macAddress].on('detected', buttonEvent.bind(null, macAddress, topic));
         });
 

--- a/server.js
+++ b/server.js
@@ -95,7 +95,7 @@ async.series([
         winston.info('Listening for %d buttons', Object.keys(config.buttons).length);
 
         Object.keys(config.buttons).forEach(function (macAddress) {
-            var topic = config.buttons[macAddress];
+            var topic = config.buttons[macAddress].name;
             var iface = config.buttons[macAddress].iface;
             if (config.mqtt.preface) {
               topic = config.mqtt.preface + '/' + topic;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature + docs update
This pull request adds all the options that are available for the node-dash-button to the config file.

**What is the current behavior?** (You can also link to an open issue here)
Listening for dash buttons is not possible for newer dash button or on devices with multiple interfaces.

**What is the new behavior (if this is a feature change)?**
Users can change the protocol and the interface that is listened on.

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Unfortunately this breaks the current structure of the config file and adds some complexity.
Adding a button was changed from:
```
    44:65:0d:dc:51:50: nerf_supplies
```
to:
```
    44:65:0d:dc:51:50:
        name: nerf_supplies
        interface: eth0     # optional
        timeout: 5000   # optional (time in ms)
        protocol: arp   # optional (one of {udp, arp, all})
```

**Other information**:
For better build times the Dockerfile order was optimized.
Version of node-dash-button was udpated.


